### PR TITLE
Change starting credits and speeder

### DIFF
--- a/MMOCoreORB/bin/scripts/managers/player_creation_manager.lua
+++ b/MMOCoreORB/bin/scripts/managers/player_creation_manager.lua
@@ -1,10 +1,10 @@
 --Should all created players start with God Mode? 1 = yes, 0 = no
 freeGodMode = 0;
 --How many cash credits new characters start with after creating a character (changed during test phase, normal value is 100)
-startingCash = 100
+startingCash = 10000
 --startingCash = 100000
 --How many bank credits new characters start with after creating a character (changed during test phase, normal value is 1000)
-startingBank = 1000
+startingBank = 0
 --startingBank = 100000
 --How many skill points a new characters start with
 skillPoints = 250
@@ -45,7 +45,7 @@ slitherhorn = "object/tangible/instrument/slitherhorn.iff"
 
 marojMelon = "object/tangible/food/foraged/foraged_fruit_s1.iff"
 
-x31Speeder = "object/tangible/deed/vehicle_deed/landspeeder_x31_deed.iff"
+swoop = "object/tangible/deed/vehicle_deed/speederbike_swoop_deed.iff"
 
 professionSpecificItems = {
 	combat_brawler = { brawlerOneHander, brawlerTwoHander, brawlerPolearm },
@@ -57,4 +57,4 @@ professionSpecificItems = {
 	social_entertainer = { slitherhorn }
 }
 
-commonStartingItems = { marojMelon, survivalKnife, x31Speeder }
+commonStartingItems = { marojMelon, survivalKnife, swoop }


### PR DESCRIPTION
Every new player starts with a Swoop Bike rather than a Landspeeder. Start with 10,000 credits rather than 1,000.